### PR TITLE
Meson: Require version 0.60.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
           echo '::group::Python packages'
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install meson==0.58
+          python -m pip install meson==0.60
           echo '::endgroup::'
 
       - name: Install GCC problem matcher

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('termite', 'c', 'cpp',
 	version: '16.5',
-	meson_version: '>=0.58.0',
+	meson_version: '>=0.60.0',
 	default_options: [
 		'b_asneeded=true',
 		'b_lundef=false',


### PR DESCRIPTION
The update to VTE 0.72.x introduced a dependency on newer Meson, so update accordingly.