### PR TITLE
Add option to make font size follow monitor DPI

### DIFF
--- a/man/termite.config.5
+++ b/man/termite.config.5
@@ -84,3 +84,7 @@ running program when this option is enabled.
 Enable bidirectional text rendering (default: \fBfalse\fR).
 .IP \fIarabic_shaping\fR
 Enable shaping of Arabic text (default: \fBfalse\fR).
+.IP \fIdpi_aware\fR
+Adapt text size depending on the DPI of the monitor in use, trying to
+make text size match the expected physical size specified in points for
+the chosen font (default: \fBfalse\fR).


### PR DESCRIPTION
Add a new `dpi_aware` option which, when enabled, makes Termite try to adjust the absolute font size to match the expected physical size in points for the current monitor. This causes text to have the same size regardless of which monitor the window is displayed onto. The adjustment is updated live as the window changes monitors as well.